### PR TITLE
Add VPC endpoint and assume role options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The AWS Bedrock Knowledge Base Function connects OpenWebUI to your AWS Bedrock K
 - Retrieve relevant information from your documents
 - Generate AI responses based on the retrieved information
 - Maintain conversation context for more coherent interactions
+- Optionally assume an IAM role for authentication
+- Support custom VPC endpoints for private access
 
 ## Installation
 
@@ -36,9 +38,15 @@ To test the function locally:
    DATA_SOURCE_ID=your_data_source_id
 
    # Optional Model Configuration
-   MODEL_ID=anthropic.claude-3-sonnet-20240229-v1:0
-   NUMBER_OF_RESULTS=10
-   ```
+  MODEL_ID=anthropic.claude-3-sonnet-20240229-v1:0
+  NUMBER_OF_RESULTS=10
+  # Optional VPC Endpoint configuration
+  BEDROCK_RUNTIME_ENDPOINT_URL=https://your-runtime-endpoint
+  BEDROCK_AGENT_ENDPOINT_URL=https://your-agent-endpoint
+  # Optional Assume Role configuration
+  AWS_ASSUME_ROLE_ARN=arn:aws:iam::123456789012:role/YourRole
+  AWS_ASSUME_ROLE_SESSION_NAME=bedrock-kb-session
+  ```
 
 3. Run the test script:
    ```
@@ -71,6 +79,10 @@ The function provides the following configuration options (valves):
 | `max_history_messages` | Maximum number of previous messages to include in history | 10 |
 | `emit_interval` | Interval in seconds between status emissions | 2.0 |
 | `enable_status_indicator` | Enable or disable status indicator emissions | true |
+| `assume_role_arn` | ARN of an IAM role to assume instead of using direct credentials | "" |
+| `assume_role_session_name` | Session name to use when assuming the IAM role | "bedrock-kb-session" |
+| `bedrock_runtime_endpoint_url` | Custom endpoint URL for bedrock-runtime | "" |
+| `bedrock_agent_endpoint_url` | Custom endpoint URL for bedrock-agent-runtime | "" |
 
 ## Required AWS Permissions
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,29 @@ The function provides the following configuration options (valves):
 | `bedrock_runtime_endpoint_url` | Custom endpoint URL for bedrock-runtime | "" |
 | `bedrock_agent_endpoint_url` | Custom endpoint URL for bedrock-agent-runtime | "" |
 
+### Using VPC Endpoints
+
+If your environment requires private connectivity, create VPC interface endpoints for
+`bedrock-runtime` and `bedrock-agent-runtime` and specify their URLs:
+
+```bash
+BEDROCK_RUNTIME_ENDPOINT_URL=https://vpce-xxxxxxxxxxxx.your-region.vpce.amazonaws.com
+BEDROCK_AGENT_ENDPOINT_URL=https://vpce-yyyyyyyyyyyy.your-region.vpce.amazonaws.com
+```
+
+All Bedrock API calls will be routed through these endpoints.
+
+### Assuming an IAM Role
+
+To use a cross-account role, provide the role ARN and an optional session name:
+
+```bash
+AWS_ASSUME_ROLE_ARN=arn:aws:iam::111122223333:role/BedrockKbRole
+AWS_ASSUME_ROLE_SESSION_NAME=kb-session
+```
+
+The function will call STS to obtain temporary credentials before creating the clients.
+
 ## Required AWS Permissions
 
 To use this function, your AWS credentials must have the following permissions:

--- a/aws_bedrock_kb_function.py
+++ b/aws_bedrock_kb_function.py
@@ -2,7 +2,7 @@
 title: AWS Bedrock Knowledge Base Function
 author: Aaron Bolton
 author_url: https://github.com/d3v0ps-cloud/AWS-Bedrock-Knowledge-Base-Function
-version: 0.1.1
+version: 0.1.3
 description: Integration with AWS Bedrock Knowledge Base for OpenWebUI only support for Claude 3 models.
 This module defines a Pipe class that utilizes AWS Bedrock Knowledge Base for retrieving information
 from your documents and providing AI-generated responses.
@@ -84,6 +84,22 @@ class Pipe:
         enable_status_indicator: bool = Field(
             default=True, description="Enable or disable status indicator emissions"
         )
+        assume_role_arn: str = Field(
+            default="",
+            description="Optional IAM role ARN to assume instead of using direct credentials",
+        )
+        assume_role_session_name: str = Field(
+            default="bedrock-kb-session",
+            description="Session name when assuming the IAM role",
+        )
+        bedrock_runtime_endpoint_url: str = Field(
+            default="",
+            description="Custom endpoint URL for bedrock-runtime (VPC Endpoint support)",
+        )
+        bedrock_agent_endpoint_url: str = Field(
+            default="",
+            description="Custom endpoint URL for bedrock-agent-runtime (VPC Endpoint support)",
+        )
         
         @validator('temperature')
         def validate_temperature(cls, v):
@@ -137,10 +153,35 @@ class Pipe:
                 session_kwargs['aws_session_token'] = self.valves.aws_session_token
                 
             session = boto3.Session(**session_kwargs)
-            
+
+            # If an assume role ARN is provided, assume the role to obtain temporary credentials
+            if self.valves.assume_role_arn:
+                try:
+                    sts_client = session.client('sts')
+                    assumed = sts_client.assume_role(
+                        RoleArn=self.valves.assume_role_arn,
+                        RoleSessionName=self.valves.assume_role_session_name,
+                    )
+                    credentials = assumed['Credentials']
+                    session = boto3.Session(
+                        aws_access_key_id=credentials['AccessKeyId'],
+                        aws_secret_access_key=credentials['SecretAccessKey'],
+                        aws_session_token=credentials['SessionToken'],
+                        region_name=self.valves.aws_region,
+                    )
+                except Exception as e:
+                    raise Exception(f"Failed to assume role: {str(e)}")
+
             try:
-                self.bedrock_client = session.client('bedrock-runtime')
-                self.bedrock_agent_client = session.client('bedrock-agent-runtime')
+                runtime_kwargs = {}
+                agent_kwargs = {}
+                if self.valves.bedrock_runtime_endpoint_url:
+                    runtime_kwargs['endpoint_url'] = self.valves.bedrock_runtime_endpoint_url
+                if self.valves.bedrock_agent_endpoint_url:
+                    agent_kwargs['endpoint_url'] = self.valves.bedrock_agent_endpoint_url
+
+                self.bedrock_client = session.client('bedrock-runtime', **runtime_kwargs)
+                self.bedrock_agent_client = session.client('bedrock-agent-runtime', **agent_kwargs)
                 self._clients_initialized = True
             except Exception as e:
                 self._clients_initialized = False

--- a/test_kb_function.py
+++ b/test_kb_function.py
@@ -212,6 +212,14 @@ async def test_kb_query(query, debug=False):
     pipe.valves.aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY')
     pipe.valves.aws_region = os.getenv('AWS_REGION')
     pipe.valves.knowledge_base_id = os.getenv('KNOWLEDGE_BASE_ID')
+
+    # Optional assume role configuration
+    pipe.valves.assume_role_arn = os.getenv('AWS_ASSUME_ROLE_ARN', "")
+    pipe.valves.assume_role_session_name = os.getenv('AWS_ASSUME_ROLE_SESSION_NAME', 'bedrock-kb-session')
+
+    # Optional VPC endpoint configuration
+    pipe.valves.bedrock_runtime_endpoint_url = os.getenv('BEDROCK_RUNTIME_ENDPOINT_URL', "")
+    pipe.valves.bedrock_agent_endpoint_url = os.getenv('BEDROCK_AGENT_ENDPOINT_URL', "")
     
     # Optional: Configure additional parameters from environment variables
     # Use a model that supports on-demand throughput (Nova Pro requires an inference profile)


### PR DESCRIPTION
## Summary
- allow assuming an IAM role when creating clients
- document assume role environment variables
- support the new valves in the test script
- bump version to 0.1.3

## Testing
- `pip install -r requirements.txt`
- `python test_kb_function.py "test"` *(fails: You must specify a region)*

------
https://chatgpt.com/codex/tasks/task_e_6851160c8d2483248cfaeecdfdba69e1