### PR TITLE
Update config defaults and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,22 @@ To test the function locally:
    # AWS Credentials
    AWS_ACCESS_KEY_ID=your_access_key_id
    AWS_SECRET_ACCESS_KEY=your_secret_access_key
-   AWS_REGION=your_aws_region
-   KNOWLEDGE_BASE_ID=your_knowledge_base_id
+   AWS_SESSION_TOKEN=placeholder
+   AWS_REGION=eu-central-1
+   KNOWLEDGE_BASE_ID=your_knowledge_base_id  # required
    DATA_SOURCE_ID=your_data_source_id
 
    # Optional Model Configuration
-  MODEL_ID=anthropic.claude-3-sonnet-20240229-v1:0
+  MODEL_ID=anthropic.claude-3-5-sonnet-20240620-v1:0
   NUMBER_OF_RESULTS=10
   # Optional VPC Endpoint configuration
-  BEDROCK_RUNTIME_ENDPOINT_URL=https://your-runtime-endpoint
-  BEDROCK_AGENT_ENDPOINT_URL=https://your-agent-endpoint
+  BEDROCK_RUNTIME_ENDPOINT_URL=https://your-runtime-endpoint # VPC Endpoint for: bedrock-runtime (Custom VPCE - leave empty if you don't work with a vpc)
+  BEDROCK_AGENT_RUNTIME_ENDPOINT_URL=https://your-agent-endpoint   # VPC Endpoint for: bedrock-agent-runtime (Custom VPCE - leave empty if you don't work with a vpc)
   # Optional Assume Role configuration
-  AWS_ASSUME_ROLE_ARN=arn:aws:iam::123456789012:role/YourRole
+  AWS_ASSUME_ROLE_ARN=placeholder
   AWS_ASSUME_ROLE_SESSION_NAME=bedrock-kb-session
   ```
+   Leave `AWS_SESSION_TOKEN` and `AWS_ASSUME_ROLE_ARN` set to `placeholder` if you are not using temporary credentials or role assumption.
 
 3. Run the test script:
    ```
@@ -67,10 +69,10 @@ The function provides the following configuration options (valves):
 |-----------|-------------|---------|
 | `aws_access_key_id` | Your AWS Access Key ID | "" |
 | `aws_secret_access_key` | Your AWS Secret Access Key | "" |
-| `aws_session_token` | AWS Session Token (optional, for temporary credentials) | "" |
-| `aws_region` | AWS Region where your Knowledge Base is located | "us-east-1" |
-| `knowledge_base_id` | ID of your AWS Bedrock Knowledge Base | "" |
-| `model_id` | AWS Bedrock model ID to use for generating responses | "anthropic.claude-3-sonnet-20240229-v1:0" |
+| `aws_session_token` | AWS Session Token (ignored if set to `placeholder`) | "placeholder" |
+| `aws_region` | AWS Region where your Knowledge Base is located | "eu-central-1" |
+| `knowledge_base_id` | ID of your AWS Bedrock Knowledge Base (required) | "" |
+| `model_id` | AWS Bedrock model ID to use for generating responses | "anthropic.claude-3-5-sonnet-20240620-v1:0" |
 | `max_tokens` | Maximum number of tokens in the response | 4096 |
 | `temperature` | Temperature for model generation (0.0-1.0) | 0.7 |
 | `top_p` | Top-p sampling parameter (0.0-1.0) | 0.9 |
@@ -79,10 +81,10 @@ The function provides the following configuration options (valves):
 | `max_history_messages` | Maximum number of previous messages to include in history | 10 |
 | `emit_interval` | Interval in seconds between status emissions | 2.0 |
 | `enable_status_indicator` | Enable or disable status indicator emissions | true |
-| `assume_role_arn` | ARN of an IAM role to assume instead of using direct credentials | "" |
+| `assume_role_arn` | IAM role ARN to assume (ignored if set to `placeholder`) | "placeholder" |
 | `assume_role_session_name` | Session name to use when assuming the IAM role | "bedrock-kb-session" |
-| `bedrock_runtime_endpoint_url` | Custom endpoint URL for bedrock-runtime | "" |
-| `bedrock_agent_endpoint_url` | Custom endpoint URL for bedrock-agent-runtime | "" |
+| `bedrock_runtime_endpoint_url` | VPC Endpoint for: bedrock-runtime (Custom VPCE - leave empty if you don't work with a VPC) | "" |
+| `bedrock_agent_runtime_endpoint_url` | VPC Endpoint for: bedrock-agent-runtime (Custom VPCE - leave empty if you don't work with a VPC) | "" |
 
 ### Using VPC Endpoints
 
@@ -91,7 +93,7 @@ If your environment requires private connectivity, create VPC interface endpoint
 
 ```bash
 BEDROCK_RUNTIME_ENDPOINT_URL=https://vpce-xxxxxxxxxxxx.your-region.vpce.amazonaws.com
-BEDROCK_AGENT_ENDPOINT_URL=https://vpce-yyyyyyyyyyyy.your-region.vpce.amazonaws.com
+BEDROCK_AGENT_RUNTIME_ENDPOINT_URL=https://vpce-yyyyyyyyyyyy.your-region.vpce.amazonaws.com
 ```
 
 All Bedrock API calls will be routed through these endpoints.

--- a/aws_bedrock_kb_function.py
+++ b/aws_bedrock_kb_function.py
@@ -48,16 +48,16 @@ class Pipe:
             default="", description="AWS Secret Access Key"
         )
         aws_session_token: str = Field(
-            default="", description="AWS Session Token (optional, for temporary credentials)"
+            default="placeholder", description="AWS Session Token (optional, ignored if set to 'placeholder')"
         )
         aws_region: str = Field(
-            default="eu-west-1", description="AWS Region"
+            default="eu-central-1", description="AWS Region"
         )
         knowledge_base_id: str = Field(
             default="", description="AWS Bedrock Knowledge Base ID"
         )
         model_id: str = Field(
-            default="anthropic.claude-3-sonnet-20240229-v1:0",
+            default="anthropic.claude-3-5-sonnet-20240620-v1:0",
             description="Model ID to use for retrieval"
         )
         max_tokens: int = Field(
@@ -85,8 +85,8 @@ class Pipe:
             default=True, description="Enable or disable status indicator emissions"
         )
         assume_role_arn: str = Field(
-            default="",
-            description="Optional IAM role ARN to assume instead of using direct credentials",
+            default="placeholder",
+            description="Optional IAM role ARN to assume (ignored if set to 'placeholder')",
         )
         assume_role_session_name: str = Field(
             default="bedrock-kb-session",
@@ -96,7 +96,7 @@ class Pipe:
             default="",
             description="Custom endpoint URL for bedrock-runtime (VPC Endpoint support)",
         )
-        bedrock_agent_endpoint_url: str = Field(
+        bedrock_agent_runtime_endpoint_url: str = Field(
             default="",
             description="Custom endpoint URL for bedrock-agent-runtime (VPC Endpoint support)",
         )
@@ -148,14 +148,14 @@ class Pipe:
                 'region_name': self.valves.aws_region
             }
             
-            # Add session token if provided
-            if self.valves.aws_session_token:
+            # Add session token if provided and not placeholder
+            if self.valves.aws_session_token and self.valves.aws_session_token != "placeholder":
                 session_kwargs['aws_session_token'] = self.valves.aws_session_token
                 
             session = boto3.Session(**session_kwargs)
 
-            # If an assume role ARN is provided, assume the role to obtain temporary credentials
-            if self.valves.assume_role_arn:
+            # If an assume role ARN is provided and not placeholder, assume the role to obtain temporary credentials
+            if self.valves.assume_role_arn and self.valves.assume_role_arn != "placeholder":
                 try:
                     sts_client = session.client('sts')
                     assumed = sts_client.assume_role(
@@ -177,8 +177,8 @@ class Pipe:
                 agent_kwargs = {}
                 if self.valves.bedrock_runtime_endpoint_url:
                     runtime_kwargs['endpoint_url'] = self.valves.bedrock_runtime_endpoint_url
-                if self.valves.bedrock_agent_endpoint_url:
-                    agent_kwargs['endpoint_url'] = self.valves.bedrock_agent_endpoint_url
+                if self.valves.bedrock_agent_runtime_endpoint_url:
+                    agent_kwargs['endpoint_url'] = self.valves.bedrock_agent_runtime_endpoint_url
 
                 self.bedrock_client = session.client('bedrock-runtime', **runtime_kwargs)
                 self.bedrock_agent_client = session.client('bedrock-agent-runtime', **agent_kwargs)

--- a/test_kb_function.py
+++ b/test_kb_function.py
@@ -219,11 +219,11 @@ async def test_kb_query(query, debug=False):
 
     # Optional VPC endpoint configuration
     pipe.valves.bedrock_runtime_endpoint_url = os.getenv('BEDROCK_RUNTIME_ENDPOINT_URL', "")
-    pipe.valves.bedrock_agent_endpoint_url = os.getenv('BEDROCK_AGENT_ENDPOINT_URL', "")
+    pipe.valves.bedrock_agent_runtime_endpoint_url = os.getenv('BEDROCK_AGENT_RUNTIME_ENDPOINT_URL', "")
     
     # Optional: Configure additional parameters from environment variables
     # Use a model that supports on-demand throughput (Nova Pro requires an inference profile)
-    pipe.valves.model_id = os.getenv('MODEL_ID', "anthropic.claude-3-sonnet-20240229-v1:0")
+    pipe.valves.model_id = os.getenv('MODEL_ID', "anthropic.claude-3-5-sonnet-20240620-v1:0")
     
     pipe.valves.number_of_results = int(os.getenv('NUMBER_OF_RESULTS', 10))  # Increase number of results
     


### PR DESCRIPTION
## Summary
- tweak credential handling logic
- update default region and model
- clarify placeholder defaults in docs
- rename endpoint descriptions
- rename agent endpoint valve

## Testing
- `python -m py_compile aws_bedrock_kb_function.py`
- `pip install -r requirements.txt`
- `AWS_REGION=eu-central-1 python test_kb_function.py --help` *(fails: credentials not set)*

------
https://chatgpt.com/codex/tasks/task_e_686b75fb7b0483248d9337ca20e9d8e6